### PR TITLE
Refactor: Decouple button component using event queue

### DIFF
--- a/components/button/include/button.h
+++ b/components/button/include/button.h
@@ -24,7 +24,8 @@ typedef enum {
 } button_click_type_t;
 
 typedef struct {
-    button_click_type_t type;   ///< Tipo do clique detectado
+    button_click_type_t type;   ///< Type of the click detected
+    gpio_num_t pin;             ///< GPIO pin of the button
 } button_event_t;
 
 // Declaração incompleta para esconder implementação interna
@@ -32,11 +33,7 @@ typedef struct button_s button_t;
 
 // Cria uma nova instância de botão, configurada no pino dado.
 // Retorna ponteiro para button_t ou NULL em erro.
-button_t *button_create(gpio_num_t pin);
-
-// Obtém a fila de eventos do botão para ler cliques.
-// Pode ser usado com xQueueReceive para aguardar eventos.
-QueueHandle_t button_get_event_queue(button_t *btn);
+button_t *button_create(gpio_num_t pin, QueueHandle_t output_queue);
 
 // Ajusta tempos de debounce (opcional)
 void button_set_debounce(button_t *btn, uint16_t debounce_press_ms, uint16_t debounce_release_ms);

--- a/main/main.c
+++ b/main/main.c
@@ -6,7 +6,55 @@
 #include "button.h"
 #include "system_events.h"
 
-const char *TAG = "MAIN";
+static const char *TAG = "MAIN";
+static const char *TAG_BUTTON_HANDLER = "BTN_HANDLER";
+
+QueueHandle_t button_app_queue = NULL;
+
+static void app_button_event_handler_task(void *param) {
+    button_event_t raw_event;
+    ESP_LOGI(TAG_BUTTON_HANDLER, "Task de handler de eventos de botão iniciada");
+
+    while (1) {
+        if (xQueueReceive(button_app_queue, &raw_event, portMAX_DELAY)) {
+            ESP_LOGI(TAG_BUTTON_HANDLER, "Raw button event: pin %d, type %d", raw_event.pin, raw_event.type);
+
+            system_event_t sys_event;
+            sys_event.data.button.button_id = raw_event.pin;
+
+            switch (raw_event.type) {
+                case BUTTON_CLICK:
+                    sys_event.type = EVENT_BUTTON_CLICK;
+                    break;
+                case BUTTON_DOUBLE_CLICK:
+                    sys_event.type = EVENT_BUTTON_DOUBLE_CLICK;
+                    break;
+                case BUTTON_LONG_CLICK:
+                    sys_event.type = EVENT_BUTTON_LONG_CLICK;
+                    break;
+                case BUTTON_VERY_LONG_CLICK:
+                    sys_event.type = EVENT_BUTTON_VERY_LONG_CLICK;
+                    break;
+                case BUTTON_TIMEOUT:
+                    sys_event.type = EVENT_BUTTON_TIMEOUT;
+                    break;
+                case BUTTON_ERROR:
+                    sys_event.type = EVENT_BUTTON_ERROR;
+                    break;
+                default:
+                    sys_event.type = EVENT_NONE; // Ou lidar com evento desconhecido
+            }
+
+            if (sys_event.type != EVENT_NONE) {
+                if (system_event_send(&sys_event)) {
+                    ESP_LOGD(TAG_BUTTON_HANDLER, "Evento do sistema enviado: %d para o botão %d", sys_event.type, sys_event.data.button.button_id);
+                } else {
+                    ESP_LOGW(TAG_BUTTON_HANDLER, "Falha ao enviar evento do sistema para o botão %d", sys_event.data.button.button_id);
+                }
+            }
+        }
+    }
+}
 
 void system_event_task(void *param) {
     system_event_t evt;
@@ -60,30 +108,47 @@ void app_main(void) {
     ESP_LOGI(TAG, "Inicializando sistema de eventos...");
     system_events_init();
 
-    // Cria botão no GPIO 23
-    ESP_LOGI(TAG, "Criando botão no GPIO 23...");
-    button_t *btn = button_create(GPIO_NUM_23);
-    if (!btn) {
-        ESP_LOGE(TAG, "FALHA ao criar botão! Abortando...");
+    // Cria a fila para eventos brutos de botão
+    ESP_LOGI(TAG, "Criando fila de eventos de botão...");
+    button_app_queue = xQueueCreate(10, sizeof(button_event_t));
+    if (button_app_queue == NULL) {
+        ESP_LOGE(TAG, "FALHA ao criar fila de eventos de botão! Abortando...");
         return;
     }
+    ESP_LOGI(TAG, "Fila de eventos de botão criada com sucesso.");
 
-    ESP_LOGI(TAG, "Botão criado com sucesso!");
+    // Cria botão no GPIO 23
+    ESP_LOGI(TAG, "Criando botão no GPIO 23...");
+    button_t *btn = button_create(GPIO_NUM_23, button_app_queue);
+    if (!btn) {
+        ESP_LOGE(TAG, "FALHA ao criar botão no GPIO 23! Abortando...");
+        // Considere deletar a fila aqui se necessário, mas como é app_main, pode só retornar.
+        return;
+    }
+    ESP_LOGI(TAG, "Botão no GPIO 23 criado com sucesso!");
 
     // Configura tempos personalizados (opcional)
-    ESP_LOGI(TAG, "Configurando tempos do botão...");
+    ESP_LOGI(TAG, "Configurando tempos do botão no GPIO 23...");
     button_set_click_times(btn, 200, 1000, 3000);
-    
-    ESP_LOGI(TAG, "Tempos configurados:");
-    ESP_LOGI(TAG, "  - Timeout duplo clique: 200ms");
-    ESP_LOGI(TAG, "  - Clique longo: 1000ms");
-    ESP_LOGI(TAG, "  - Clique muito longo: 3000ms");
+    ESP_LOGI(TAG, "Tempos configurados para GPIO 23.");
 
-    // Cria task que vai processar eventos do sistema
+    // Cria task que vai processar eventos do sistema (recebidos do app_button_event_handler_task)
     ESP_LOGI(TAG, "Criando task de eventos do sistema...");
-    xTaskCreate(system_event_task, "sys_evt", 2048, NULL, 5, NULL);
+    if (xTaskCreate(system_event_task, "sys_evt_task", 2048, NULL, 5, NULL) != pdPASS) {
+        ESP_LOGE(TAG, "FALHA ao criar task de eventos do sistema! Abortando...");
+        return;
+    }
+    ESP_LOGI(TAG, "Task de eventos do sistema criada com sucesso.");
 
-    ESP_LOGI(TAG, "Sistema inicializado! Teste o botão:");
+    // Cria a task que lida com eventos brutos dos botões
+    ESP_LOGI(TAG, "Criando task handler de eventos de botão...");
+    if (xTaskCreate(app_button_event_handler_task, "btn_handler_task", 2048, NULL, 5, NULL) != pdPASS) {
+        ESP_LOGE(TAG, "FALHA ao criar task handler de eventos de botão! Abortando...");
+        return;
+    }
+    ESP_LOGI(TAG, "Task handler de eventos de botão criada com sucesso.");
+
+    ESP_LOGI(TAG, "Sistema inicializado! Teste os botões:");
     ESP_LOGI(TAG, "  - Pressione rapidamente: clique simples");  
     ESP_LOGI(TAG, "  - Pressione 2x rapidamente: clique duplo");
     ESP_LOGI(TAG, "  - Mantenha por 1s: clique longo");
@@ -93,10 +158,16 @@ void app_main(void) {
     ESP_LOGI(TAG, "app_main finalizado, sistema rodando...");
 
     // Opcional: você pode adicionar mais botões aqui
-    
-    button_t *btn2 = button_create(GPIO_NUM_22);
+    ESP_LOGI(TAG, "Criando segundo botão no GPIO 22...");
+    button_t *btn2 = button_create(GPIO_NUM_22, button_app_queue);
     if (btn2) {
         ESP_LOGI(TAG, "Segundo botão criado no GPIO 22");
+        // Pode configurar tempos diferentes para este botão se desejar
+        // button_set_click_times(btn2, 250, 1200, 3500);
+    } else {
+        ESP_LOGE(TAG, "FALHA ao criar segundo botão no GPIO 22!");
+        // Não precisa abortar tudo, o primeiro botão e tasks ainda podem funcionar
     }
     
+    ESP_LOGI(TAG, "app_main finalizado, sistema rodando...");
 }


### PR DESCRIPTION
The button component has been refactored to remove its direct dependency on the system_events component.

Key changes:
- The `button` component no longer includes `system_events.h` or calls `system_event_send()` directly.
- `button_create()` now accepts a `QueueHandle_t` (output_queue) as an argument.
- The `button_task` within the button component now sends detected button events (as `button_event_t` containing click type and pin number) to this `output_queue`.
- `button_event_t` in `button.h` has been updated to include `gpio_num_t pin` to make events self-descriptive.
- `main.c` has been updated to:
    - Create an intermediate queue (`button_app_queue`).
    - Pass this queue to `button_create()` for each button instance.
    - Implement a new task (`app_button_event_handler_task`) that receives raw `button_event_t` items from `button_app_queue`.
    - This handler task maps the raw button event to a `system_event_t` and then sends it to the original `system_events` queue.
- The `system_events` component itself remains unchanged.

This change enhances modularity, allowing the button component to be reused more easily in projects with different event handling mechanisms. The `main.c` acts as the bridge, preserving the existing system-wide event processing logic.